### PR TITLE
bug/case_tester_lambda

### DIFF
--- a/django_swagger_tester/configuration.py
+++ b/django_swagger_tester/configuration.py
@@ -154,7 +154,7 @@ class SwaggerTesterSettings:
 
     @property
     def case_tester(self) -> Callable:
-        return self.settings.get('CASE_TESTER', lambda: None)
+        return self.settings.get('CASE_TESTER', lambda *args: None)
 
     @property
     def camel_case_parser(self) -> bool:


### PR DESCRIPTION
This PR fixes the issue with the default lambda function receiving args even when no camel case converter is used. 