### PR TITLE
Document and test i18n endpoint in static schema

### DIFF
--- a/demo/api/swagger/auto_schemas.py
+++ b/demo/api/swagger/auto_schemas.py
@@ -167,7 +167,7 @@ def languages_auto_schema():
                 title='Success',
                 type=TYPE_OBJECT,
                 properties={
-                    'Languages': Schema(
+                    'languages': Schema(
                         title='Success',
                         type=TYPE_ARRAY,
                         items=generic_string_schema(example='test', description='test'),

--- a/demo/api/views/i18n.py
+++ b/demo/api/views/i18n.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext as _
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
@@ -9,7 +11,7 @@ from django_swagger_tester.views import ResponseValidationView
 class Languages(ResponseValidationView):
 
     @languages_auto_schema()
-    def get(self, request: Request) -> Response:
+    def get(self, request: Request, version: int) -> Response:
         return Response({'languages': [
-            'French', 'Spanish', 'Greek', 'Italian', 'Portugese'
+            _('French'), _('Spanish'), _('Greek'), _('Italian'), _('Portuguese')
         ]}, HTTP_200_OK)

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -96,7 +96,7 @@ LANGUAGES = [
   ('en', _('English')),
 ]
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_L10N = True

--- a/demo/static_schemas/openapi-schema.yml
+++ b/demo/static_schemas/openapi-schema.yml
@@ -225,3 +225,20 @@ paths:
       responses:
         '204':
           description: ''
+  /{lang}/api/v1/i18n:
+    get:
+      operationId: listLanguages
+      description: ''
+      parameters:
+        - name: lang
+          in: path
+          enum: [en, de]
+          description: 'The response content language.'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -48,7 +48,7 @@ api_urlpatterns = [
 ]
 
 internationalised_urlpatterns = i18n_patterns(
-    path('api/v1/i18n', Languages.as_view())
+    path('api/<version:version>/i18n', Languages.as_view()),
 )
 
 

--- a/tests/test_testers/test_validate_response/test_static.py
+++ b/tests/test_testers/test_validate_response/test_static.py
@@ -20,6 +20,20 @@ good_test_data = [
             {'name': 'Tesla', 'color': 'black', 'height': 'Medium height', 'width': 'Wide', 'length': '2 meters'},
         ],
     },
+    {
+        'url': '/i18n',
+        'lang': 'en',
+        'expected_response': {
+            'languages': ['French', 'Spanish', 'Greek', 'Italian', 'Portuguese'],
+        },
+    },
+    {
+        'url': '/i18n',
+        'lang': 'de',
+        'expected_response': {
+            'languages': ['Französisch', 'Spanisch', 'Griechisch', 'Italienisch', 'Portugiesisch'],
+        },
+    },
 ]
 
 bad_test_data = [
@@ -40,7 +54,7 @@ bad_test_data = [
         ],
     },
 ]
-yml_path = str(django_settings.BASE_DIR) + '/openapi-schema.yml'
+yml_path = str(django_settings.BASE_DIR) + '/static_schemas/openapi-schema.yml'
 
 
 def test_endpoints_static_schema(client, monkeypatch, transactional_db) -> None:  # noqa: TYP001
@@ -49,7 +63,9 @@ def test_endpoints_static_schema(client, monkeypatch, transactional_db) -> None:
     """
     monkeypatch.setattr(django_settings, 'SWAGGER_TESTER', {'PATH': yml_path, 'SCHEMA_LOADER': StaticSchemaLoader})
     for item in good_test_data:
-        response = client.get('/api/v1' + item['url'])  # type: ignore
+        lang_prefix = '/' + item['lang'] if 'lang' in item else ''
+        url = lang_prefix + '/api/v1' + item['url']
+        response = client.get(url)
         assert response.status_code == 200
         assert response.json() == item['expected_response']
-        validate_response(response=response, method='GET', route='/api/v1' + item['url'])  # type: ignore
+        validate_response(response=response, method='GET', route=url)

--- a/tests/test_utils/test_get_endpoints.py
+++ b/tests/test_utils/test_get_endpoints.py
@@ -12,15 +12,16 @@ def test_get_endpoint_paths():
     """
     urls = list(set(get_endpoint_paths()))
     expected = [
-        '/api/v1/trucks/incorrect',
-        '/api/v1/{vehicle_type}/correct',
-        '/api/v1/{vehicle_type}/incorrect',
-        '/api/v1/vehicles',
-        '/api/v1/items',
-        '/api/v1/trucks/correct',
-        '/api/v1/snake-case',
-        '/api/v1/animals',
-        '/api/v1/exempt-endpoint',
+        '/api/{version}/trucks/incorrect',
+        '/api/{version}/{vehicle_type}/correct',
+        '/api/{version}/{vehicle_type}/incorrect',
+        '/api/{version}/vehicles',
+        '/api/{version}/items',
+        '/api/{version}/trucks/correct',
+        '/api/{version}/snake-case/',
+        '/api/{version}/animals',
+        '/api/{version}/exempt-endpoint',
+        '/en/api/{version}/i18n',
     ]
-    assert [url in expected for url in urls]
+    assert all([url in expected for url in urls])
     assert len(expected) == len(urls)


### PR DESCRIPTION
As discussed in #115.

I added the internationalized route in `demo/static_schemas/openapi-schema.yml` and added some test items in `tests/test_testers/test_validate_response/test_static.py`. This now reproduces the error I got when documenting the endpoint as `/{lang}/api/...`.

I also noticed that some tests relating to the static schemas didn't seem to work properly, so I tried to fix them (let me know if I just misunderstood them). Specifically, the `yml_path` in `test_static.py` seemed to point to the wrong YAML file (?), and the list comparison test in `test_get_endpoints.py` didn't actually check the content of the lists.