### PR TITLE
Update changelog and bump version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,14 @@ Changelog
 
 **Improvements**
 
+* Support added for split files in the StaticSchemaLoader class by @askoretskiy
+* Django APITestCase class added by @Goldziher
+
+2.1.2 2020-10-06
+----------------
+
+**Improvements**
+
 * Fixed minor settings bug
 
 2.1.1 2020-09-27

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,3 +21,10 @@ Nice to know
 ------------
 - To build docs locally, simply cd into ``/docs`` and run ``make html``. You can then navigate to ``file:///<your path>/django-swagger-tester/docs/build/html/index.html`` to browse them.
 - Static files are gitignored, so to generate static assets locally, you should run ``manage.py collectstatic``.
+- To publish a test-release, run
+
+```
+poetry config repositories.test https://test.pypi.org/legacy/
+poetry config pypi-token.test ${{ secrets.TEST_PYPI_TOKEN }}
+poetry publish --build --no-interaction --repository test
+```

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,6 +1,0 @@
-Project Maintainers
--------------------
-
-* Sondre Lillebø Gundersen | `@sondrelg <https://github.com/sondrelg>`_
-* Jonas Krüger Svensson | `@JonasKs <https://github.com/JonasKs>`_
-* Na'aman Hirschfeld | `@Goldziher <https://github.com/Goldziher>`_

--- a/django_swagger_tester/__init__.py
+++ b/django_swagger_tester/__init__.py
@@ -1,5 +1,5 @@
 default_app_config = 'django_swagger_tester.apps.DjangoSwaggerTesterConfig'
 
-__version__ = '2.1.2'  # Remember to also change pyproject.toml version
+__version__ = '2.1.3'  # Remember to also change pyproject.toml version
 __author__ = 'Sondre Lillebø Gundersen'
 __all__ = ['testing', 'case_testers', 'loaders', 'exceptions']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-swagger-tester"
-version = "2.1.2"  # Remember to also change in django_swagger_tester/__init__.py version
+version = "2.1.3"  # Remember to also change in django_swagger_tester/__init__.py version
 description = "Django test utility for validating Swagger documentation"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]
 license = "BSD-4-Clause"


### PR DESCRIPTION
- Bumps version to 2.1.3
- Removes CONTRIBUTORS.md since we already have this feature built into the github repo
- Updates the changelog